### PR TITLE
[fix] #38 API 관련 예외처리 추가 및 일부 코드 수정

### DIFF
--- a/src/main/java/com/kusher/kusher_in_korea/auth/domain/User.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/domain/User.java
@@ -22,7 +22,7 @@ public class User {
 
     private String userType; // 유저유형 (유저 or 점주)
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY , cascade = CascadeType.ALL)
     @JoinColumn(name = "cart_id")
     private Cart cart; // 유저와 장바구니는 일대일 관계
 

--- a/src/main/java/com/kusher/kusher_in_korea/auth/dto/RequestUserDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/dto/RequestUserDto.java
@@ -5,6 +5,6 @@ import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-public class RequestUserDto { // 유저 추가 요청
+public class RequestUserDto { // 회원가입 및 로그인 요청
     private String userEmail; // 유저이메일
 }

--- a/src/main/java/com/kusher/kusher_in_korea/auth/service/UserService.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/service/UserService.java
@@ -49,7 +49,7 @@ public class UserService {
     }
 
     // 로그인
-    public UserDto login(UserDto userDto) {
+    public UserDto login(RequestUserDto userDto) {
         User user = userRepository.findByUserEmail(userDto.getUserEmail()).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
         return new UserDto(user);
     }

--- a/src/main/java/com/kusher/kusher_in_korea/auth/service/UserService.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/service/UserService.java
@@ -3,6 +3,7 @@ package com.kusher.kusher_in_korea.auth.service;
 import com.kusher.kusher_in_korea.auth.dto.RequestUserDto;
 import com.kusher.kusher_in_korea.ingredient.domain.Cart;
 import com.kusher.kusher_in_korea.ingredient.dto.response.CartDto;
+import com.kusher.kusher_in_korea.ingredient.repository.CartRepository;
 import com.kusher.kusher_in_korea.tabling.domain.Reservation;
 import com.kusher.kusher_in_korea.auth.domain.User;
 import com.kusher.kusher_in_korea.tabling.dto.response.ReservationDto;
@@ -13,24 +14,30 @@ import com.kusher.kusher_in_korea.util.exception.CustomException;
 import com.kusher.kusher_in_korea.util.exception.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
     private final ReservationRepository reservationRepository;
+    private final CartRepository cartRepository;
 
     // 유저 추가
+    @Transactional
     public Long createUser(RequestUserDto userDto) {
         ValidationDuplicateUser(userDto.getUserEmail());
         User user = User.createUser(userDto);
         Cart cart = Cart.createCart(user); // 유저 생성 시 유저가 사용할 장바구니도 생성
-        return userRepository.save(user).getId();
+        Long id = userRepository.save(user).getId();
+        cartRepository.save(cart);
+        return id;
     }
 
     // 유저명 중복 방지

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/domain/Cart.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/domain/Cart.java
@@ -18,7 +18,7 @@ public class Cart { // User와 장바구니는 일대일 관계
     @Column(name = "cart_id")
     private Long id;
 
-    @OneToOne(mappedBy = "cart", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "cart", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private User user; // 장바구니를 소유한 회원
 
     @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true) // orphanRemoval: 장바구니에서 재료를 삭제하면 DB에서도 삭제

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/repository/CartRepository.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/repository/CartRepository.java
@@ -1,6 +1,7 @@
 package com.kusher.kusher_in_korea.ingredient.repository;
 
 import com.kusher.kusher_in_korea.ingredient.domain.Cart;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/service/IngredientService.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/service/IngredientService.java
@@ -14,11 +14,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class IngredientService { // 식재료 및 카테고리를 제어한다.
 
@@ -61,6 +63,7 @@ public class IngredientService { // 식재료 및 카테고리를 제어한다.
      * 아래부터는 서버에서 사용하기 위한 관리용 메서드
      */
     // 식재료 추가
+    @Transactional
     public Long addIngredient(CreateIngredientDto ingredientDto, String imageUrl) {
         validateDuplicateIngredient(ingredientDto.getIngredientName());
         Category category = categoryRepository.findByName(ingredientDto.getIngredientCategory()).orElseThrow(() -> new CustomException(ResponseCode.CATEGORY_NOT_FOUND));
@@ -77,6 +80,7 @@ public class IngredientService { // 식재료 및 카테고리를 제어한다.
     }
 
     // 식재료 수정
+    @Transactional
     public Long updateIngredient(Long ingredientId, RequestIngredientDto requestIngredientDto) {
         Ingredient ingredient = ingredientRepository.findById(ingredientId).orElseThrow(() -> new CustomException(ResponseCode.INGREDIENT_NOT_FOUND));
         Category category = categoryRepository.findByName(requestIngredientDto.getIngredientCategory()).orElseThrow(() -> new CustomException(ResponseCode.CATEGORY_NOT_FOUND));
@@ -85,11 +89,13 @@ public class IngredientService { // 식재료 및 카테고리를 제어한다.
     }
 
     // 식재료 삭제
+    @Transactional
     public void deleteIngredient(Long ingredientId) {
         ingredientRepository.deleteById(ingredientId);
     }
 
     // 카테고리 추가
+    @Transactional
     public Long addCategory(String categoryName) {
         validateDuplicateCategory(categoryName);
         Category category = Category.createCategory(categoryName);
@@ -105,6 +111,7 @@ public class IngredientService { // 식재료 및 카테고리를 제어한다.
     }
 
     // 카테고리 수정
+    @Transactional
     public Long updateCategory(Long categoryId, String categoryName) {
         Category category = categoryRepository.findById(categoryId).orElseThrow(() -> new CustomException(ResponseCode.CATEGORY_NOT_FOUND));
         category.setName(categoryName);
@@ -112,6 +119,7 @@ public class IngredientService { // 식재료 및 카테고리를 제어한다.
     }
 
     // 카테고리 삭제
+    @Transactional
     public void deleteCategory(Long categoryId) {
         categoryRepository.deleteById(categoryId);
     }

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/service/OrdersService.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/service/OrdersService.java
@@ -14,11 +14,13 @@ import com.kusher.kusher_in_korea.util.exception.CustomException;
 import com.kusher.kusher_in_korea.util.exception.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class OrdersService {
 
@@ -37,6 +39,7 @@ public class OrdersService {
     }
 
     // 장바구니 내부에 특정 상품 추가 (장바구니 담기)
+    @Transactional
     public Long addCartIngredient(AddCartIngredientDto addCartIngredientDto) {
         Cart cart = cartRepository.findById(addCartIngredientDto.getCartId()).orElseThrow(() -> new CustomException(ResponseCode.CART_NOT_FOUND));
         CartIngredient cartIngredient = CartIngredient.createCartIngredient(cart, addCartIngredientDto.getCount(), ingredientRepository.findById(addCartIngredientDto.getIngredientId()).orElseThrow(() -> new CustomException(ResponseCode.INGREDIENT_NOT_FOUND)));
@@ -44,6 +47,7 @@ public class OrdersService {
     }
 
     // 장바구니 내부 특정 상품 개수 증가
+    @Transactional
     public void increaseCartIngredient(Long cartIngredientId) {
         CartIngredient cartIngredient = cartIngredientRepository.findById(cartIngredientId).orElseThrow(() -> new CustomException(ResponseCode.CART_INGREDIENT_NOT_FOUND));
         cartIngredient.addCount();
@@ -51,6 +55,7 @@ public class OrdersService {
     }
 
     // 장바구니 내부 특정 상품 개수 감소
+    @Transactional
     public void decreaseCartIngredient(Long cartIngredientId) {
         CartIngredient cartIngredient = cartIngredientRepository.findById(cartIngredientId).orElseThrow(() -> new CustomException(ResponseCode.CART_INGREDIENT_NOT_FOUND));
         cartIngredient.subtractCount();
@@ -58,12 +63,14 @@ public class OrdersService {
     }
 
     // 장바구니 내부 특정 상품 삭제
+    @Transactional
     public void deleteCartIngredient(Long cartIngredientId) {
         CartIngredient cartIngredient = cartIngredientRepository.findById(cartIngredientId).orElseThrow(() -> new CustomException(ResponseCode.CART_INGREDIENT_NOT_FOUND));
         cartIngredientRepository.delete(cartIngredient);
     }
 
     // 주문 생성
+    @Transactional
     public Long createOrder(CreateOrdersDto createOrdersDto) {
         User user = userRepository.findById(createOrdersDto.getUserId()).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
         Orders orders = Orders.createOrders(user, createOrdersDto.getOrderStatus(), createOrdersDto.getDelivery());
@@ -78,12 +85,14 @@ public class OrdersService {
     }
 
     // 주문 취소
+    @Transactional
     public void cancelOrder(Long orderId) {
         Orders order = ordersRepository.findById(orderId).orElseThrow(() -> new CustomException(ResponseCode.ORDERS_NOT_FOUND));
         order.cancel();
     }
 
     // 주문 수정(배송지 수정)
+    @Transactional
     public Long updateOrder(Long orderId, Delivery delivery) {
         Orders order = ordersRepository.findById(orderId).orElseThrow(() -> new CustomException(ResponseCode.ORDERS_NOT_FOUND));
         order.update(delivery);

--- a/src/main/java/com/kusher/kusher_in_korea/reviewfeedback/service/FeedbackService.java
+++ b/src/main/java/com/kusher/kusher_in_korea/reviewfeedback/service/FeedbackService.java
@@ -10,10 +10,12 @@ import com.kusher.kusher_in_korea.util.exception.CustomException;
 import com.kusher.kusher_in_korea.util.exception.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class FeedbackService {
 

--- a/src/main/java/com/kusher/kusher_in_korea/reviewfeedback/service/ReviewService.java
+++ b/src/main/java/com/kusher/kusher_in_korea/reviewfeedback/service/ReviewService.java
@@ -12,11 +12,13 @@ import com.kusher.kusher_in_korea.util.exception.CustomException;
 import com.kusher.kusher_in_korea.util.exception.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Service
 public class ReviewService {
     private final ReviewRepository reviewRepository;
@@ -24,6 +26,7 @@ public class ReviewService {
     private final RestaurantRepository restaurantRepository;
 
     // 리뷰 생성
+    @Transactional
     public Long createReview(CreateReviewDto createReviewDto, String imageUrl) {
         User user = userRepository.findById(createReviewDto.getUserId())
                 .orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
@@ -42,6 +45,8 @@ public class ReviewService {
 
     // 특정 식당에 대한 리뷰 조회
     public List<ReviewDto> getReviewsByRestaurantId(Long restaurantId) {
+        Restaurant restaurant = restaurantRepository.findById(restaurantId)
+                .orElseThrow(() -> new CustomException(ResponseCode.RESTAURANT_NOT_FOUND));
         List<Review> reviews = reviewRepository.findByRestaurantId(restaurantId);
 
         return reviews.stream()
@@ -51,6 +56,8 @@ public class ReviewService {
 
     // 특정 유저가 남긴 리뷰 조회
     public List<ReviewDto> getReviewsByUserId(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
         List<Review> reviews = reviewRepository.findByUserId(userId);
 
         return reviews.stream()
@@ -59,6 +66,7 @@ public class ReviewService {
     }
 
     // 리뷰 삭제
+    @Transactional
     public void deleteReview(Long reviewId) {
         reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new CustomException(ResponseCode.REVIEW_NOT_FOUND));

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/service/ReservationService.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/service/ReservationService.java
@@ -13,6 +13,7 @@ import com.kusher.kusher_in_korea.util.exception.ReserveFailException;
 import com.kusher.kusher_in_korea.util.exception.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -21,6 +22,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ReservationService {
 
@@ -42,6 +44,7 @@ public class ReservationService {
     }
 
     // 예약 생성
+    @Transactional
     public Long createReservation(CreateReservationDto createReservationDto) {
         Optional<Restaurant> optionalRestaurant = restaurantRepository.findById(createReservationDto.getRestaurantId());
         Restaurant restaurant = optionalRestaurant.orElseThrow(() -> new CustomException(ResponseCode.RESTAURANT_NOT_FOUND));
@@ -77,6 +80,7 @@ public class ReservationService {
     }
 
     // 예약 수정(시간, 인원수)
+    @Transactional
     public Long updateReservation(Long reservationId, UpdateReservationDto updateReservationDto) {
         Reservation reservation = reservationRepository.findById(reservationId).orElseThrow(() -> new CustomException(ResponseCode.RESERVATION_NOT_FOUND));
         Restaurant restaurant = restaurantRepository.findById(updateReservationDto.getRestaurantId()).orElseThrow(() -> new CustomException(ResponseCode.RESTAURANT_NOT_FOUND));
@@ -89,6 +93,7 @@ public class ReservationService {
     }
 
     // 예약 취소(상태 변경)
+    @Transactional
     public void cancelReservation(Long reservationId) {
         Reservation reservation = reservationRepository.findById(reservationId).orElseThrow(() -> new CustomException(ResponseCode.RESERVATION_NOT_FOUND));
         if(!reservation.isCancelable()) {

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/service/RestaurantService.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/service/RestaurantService.java
@@ -13,12 +13,14 @@ import com.kusher.kusher_in_korea.util.exception.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class RestaurantService {
 
@@ -53,16 +55,18 @@ public class RestaurantService {
     }
 
     // 새 식당 추가 (점주 타입만 가능)
+    @Transactional
     public Long saveRestaurant(CreateRestaurantDto createRestaurantDto) {
         User user = userRepository.findById(createRestaurantDto.getUserId()).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
-        if (!Objects.equals(user.getUserType(), "점주"))
-            throw new CustomException(ResponseCode.NOT_RESTAURANT_OWNER);
+        /*if (!Objects.equals(user.getUserType(), "점주"))
+            throw new CustomException(ResponseCode.NOT_RESTAURANT_OWNER);*/
         Restaurant restaurant = Restaurant.createRestaurant(createRestaurantDto);
         restaurantRepository.save(restaurant);
         return restaurant.getId();
     }
 
     // 특정 식당 정보 수정
+    @Transactional
     public Long updateRestaurant(Long restaurantId, UpdateRestaurantDto restaurantDto) {
         Long userId = restaurantDto.getUserId();
         if (!isOwner(restaurantId, userId)) throw new CustomException(ResponseCode.NOT_RESTAURANT_OWNER);
@@ -74,6 +78,7 @@ public class RestaurantService {
     }
 
     // 특정 식당 메뉴 추가
+    @Transactional
     public Long saveRestaurantMenu(Long restaurantId, CreateRestaurantMenuDto createRestaurantMenuDto) {
         Restaurant restaurant = restaurantRepository.findById(restaurantId).orElseThrow(() -> new CustomException(ResponseCode.RESTAURANT_NOT_FOUND));
         if (!Objects.equals(createRestaurantMenuDto.getOwnerId(), restaurant.getOwnerId()))
@@ -85,6 +90,7 @@ public class RestaurantService {
     }
 
     // 특정 식당 메뉴 수정
+    @Transactional
     public void updateRestaurantMenu(Long restaurantId, Long menuId, UpdateRestaurantMenuDto restaurantMenuDto) {
         Restaurant restaurant = restaurantRepository.findById(restaurantId).orElseThrow(() -> new CustomException(ResponseCode.RESTAURANT_NOT_FOUND));
         if (!Objects.equals(restaurantMenuDto.getOwnerId(), restaurant.getOwnerId()))
@@ -94,6 +100,7 @@ public class RestaurantService {
     }
 
     // 특정 식당 메뉴 삭제
+    @Transactional
     public void deleteRestaurantMenu(Long restaurantId, Long menuId, DeleteRestaurantMenuDto deleteRestaurantMenuDto) {
         Restaurant restaurant = restaurantRepository.findById(restaurantId).orElseThrow(() -> new CustomException(ResponseCode.RESTAURANT_NOT_FOUND));
         if (!Objects.equals(deleteRestaurantMenuDto.getOwnerId(), restaurant.getOwnerId()))

--- a/src/main/java/com/kusher/kusher_in_korea/util/api/ApiResponse.java
+++ b/src/main/java/com/kusher/kusher_in_korea/util/api/ApiResponse.java
@@ -27,6 +27,6 @@ public class ApiResponse<T> {
     }
 
     public static <T> ApiResponse<T> fail(ResponseCode responseCode){
-        return new ApiResponse<T>(new ApiHeader(responseCode.getHttpStatusCode(), responseCode.getMessage()), new ApiBody<>(null, responseCode.getMessage()));
+        return new ApiResponse<T>(new ApiHeader(responseCode.getHttpStatusCode(), responseCode.getMessage()));
     }
 }

--- a/src/main/java/com/kusher/kusher_in_korea/util/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kusher/kusher_in_korea/util/exception/GlobalExceptionHandler.java
@@ -1,4 +1,20 @@
 package com.kusher.kusher_in_korea.util.exception;
 
+import com.kusher.kusher_in_korea.util.api.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+
+@Slf4j
+@ControllerAdvice
 public class GlobalExceptionHandler {
+    @ExceptionHandler(value = {CustomException.class})
+    // 예외 발생 시 클라이언트에게 전달할 응답을 생성하는 메소드
+    public ResponseEntity<ApiResponse> handleCustomException(CustomException e, WebRequest request) {
+        log.error("handleCustomException", e);
+        return new ResponseEntity<>(ApiResponse.fail(e.getResponseCode()), HttpStatus.valueOf(e.getResponseCode().getHttpStatusCode()));
+    }
 }


### PR DESCRIPTION
* API 통신 도중 예외 발생 시 예외 전용 Response 객체 추가
* Service 계층에서 생성/수정/삭제 로직에 @Transactional 어노테이션 추가 (원자성 부여하여 데이터 무결성 유지)
* 유저-카트 간 영속성 유지를 위해 cascade 조건 보강