### PR TITLE
[fix] #46 클라이언트 요청사항 API에 반영

### DIFF
--- a/src/main/java/com/kusher/kusher_in_korea/auth/controller/UserController.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/controller/UserController.java
@@ -1,6 +1,9 @@
 package com.kusher.kusher_in_korea.auth.controller;
 
-import com.kusher.kusher_in_korea.auth.dto.RequestUserDto;
+import com.kusher.kusher_in_korea.auth.dto.CreateUserDto;
+import com.kusher.kusher_in_korea.auth.dto.LoginDto;
+import com.kusher.kusher_in_korea.auth.dto.UpdateUserDto;
+import com.kusher.kusher_in_korea.image.service.ImageUploadService;
 import com.kusher.kusher_in_korea.ingredient.dto.response.CartDto;
 import com.kusher.kusher_in_korea.ingredient.dto.response.OrdersDto;
 import com.kusher.kusher_in_korea.ingredient.service.OrdersService;
@@ -14,6 +17,7 @@ import com.kusher.kusher_in_korea.util.exception.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -24,19 +28,31 @@ public class UserController {
     private final UserService userService;
     private final ReviewService reviewService;
     private final OrdersService ordersService;
+    private final ImageUploadService imageUploadService;
 
     // 회원가입
     @PostMapping("/create")
-    public ApiResponse<Long> createUser(@RequestBody RequestUserDto userDto) {
-        Long userId = userService.createUser(userDto);
+    public ApiResponse<Long> createUser(CreateUserDto userDto) throws IOException {
+        String imageUrl = "";
+        if(userDto.getProfileImage() != null) {
+            imageUrl = imageUploadService.uploadImage(userDto.getProfileImage());
+        }
+        Long userId = userService.createUser(userDto, imageUrl);
         return ApiResponse.success(userId, ResponseCode.USER_CREATE_SUCCESS.getMessage());
     }
 
     // 로그인
     @PostMapping("/login")
-    public ApiResponse<UserDto> login(@RequestBody RequestUserDto userDto) {
+    public ApiResponse<UserDto> login(@RequestBody LoginDto userDto) {
         UserDto loginUser = userService.login(userDto);
         return ApiResponse.success(loginUser, ResponseCode.LOGIN_SUCCESS.getMessage());
+    }
+
+    // 유저가 로그인한 적이 있는지 확인
+    @GetMapping("/check/{userEmail}")
+    public ApiResponse<Boolean> checkLogin(@PathVariable String userEmail) {
+        Boolean checkLogin = userService.checkLogin(userEmail);
+        return ApiResponse.success(checkLogin, ResponseCode.LOGIN_SUCCESS.getMessage());
     }
 
     // 유저 정보 조회
@@ -44,6 +60,17 @@ public class UserController {
     public ApiResponse<UserDto> getUser(@PathVariable Long userId) {
         UserDto userDto = userService.getUser(userId);
         return ApiResponse.success(userDto, ResponseCode.USER_READ_SUCCESS.getMessage());
+    }
+
+    // 유저 정보 수정
+    @PutMapping("/{userId}")
+    public ApiResponse<Long> updateUser(@PathVariable Long userId, UpdateUserDto userDto) throws IOException {
+        String imageUrl = "";
+        if(userDto.getProfileImage() != null) {
+            imageUrl = imageUploadService.uploadImage(userDto.getProfileImage());
+        }
+        Long updateUserId = userService.updateUser(userId, userDto, imageUrl);
+        return ApiResponse.success(updateUserId, ResponseCode.USER_UPDATE_SUCCESS.getMessage());
     }
 
     // 유저의 예약 조회

--- a/src/main/java/com/kusher/kusher_in_korea/auth/domain/User.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/domain/User.java
@@ -1,6 +1,5 @@
 package com.kusher.kusher_in_korea.auth.domain;
 
-import com.kusher.kusher_in_korea.auth.dto.RequestUserDto;
 import com.kusher.kusher_in_korea.ingredient.domain.Cart;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -18,20 +17,40 @@ public class User {
     @Column(name = "user_id")
     private Long id; // 유저번호
 
+    private String userName; // 유저이름
+
     private String userEmail; // 유저이메일
 
+    private String userPhone; // 유저전화번호
+
     private String userType; // 유저유형 (유저 or 점주)
+
+    private String profileImage; // 유저 프로필 이미지
+
+    private String userAddress; // 유저 주소
 
     @OneToOne(fetch = FetchType.LAZY , cascade = CascadeType.ALL)
     @JoinColumn(name = "cart_id")
     private Cart cart; // 유저와 장바구니는 일대일 관계
 
     // 생성 메서드
-    public static User createUser(RequestUserDto userDto) {
+    public static User createUser(String userName, String userEmail, String userPhone, String profileImage, String userAddress) {
         User user = new User();
-        user.userEmail = userDto.getUserEmail();
-        user.userType = "유저";
+        user.userName = userName;
+        user.userEmail = userEmail;
+        user.userPhone = userPhone;
+        user.userType = "user";
+        user.profileImage = profileImage;
+        user.userAddress = userAddress;
         return user;
+    }
+
+    // 유저 정보 수정
+    public void updateUser(String userName, String userPhone, String profileImage, String userAddress) {
+        this.userName = userName;
+        this.userPhone = userPhone;
+        this.profileImage = profileImage;
+        this.userAddress = userAddress;
     }
 
     public void setCart(Cart cart) {

--- a/src/main/java/com/kusher/kusher_in_korea/auth/domain/User.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/domain/User.java
@@ -29,6 +29,8 @@ public class User {
 
     private String userAddress; // 유저 주소
 
+    private boolean isFirstLogin; // 첫 로그인 여부
+
     @OneToOne(fetch = FetchType.LAZY , cascade = CascadeType.ALL)
     @JoinColumn(name = "cart_id")
     private Cart cart; // 유저와 장바구니는 일대일 관계
@@ -42,6 +44,7 @@ public class User {
         user.userType = "user";
         user.profileImage = profileImage;
         user.userAddress = userAddress;
+        user.isFirstLogin = true; // 회원가입 직후엔 첫 로그인이므로 true
         return user;
     }
 
@@ -57,4 +60,7 @@ public class User {
         this.cart = cart;
     }
 
+    public void setNotFirstLogin(){
+        this.isFirstLogin = false;
+    }
 }

--- a/src/main/java/com/kusher/kusher_in_korea/auth/dto/CreateUserDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/dto/CreateUserDto.java
@@ -1,0 +1,15 @@
+package com.kusher.kusher_in_korea.auth.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@NoArgsConstructor
+public class CreateUserDto { // 신규 회원가입 요청
+    private String userName; // 유저이름
+    private String userEmail; // 유저이메일
+    private String userPhone; // 유저전화번호
+    private MultipartFile profileImage; // 유저 프로필 이미지 파일
+    private String userAddress; // 유저 주소
+}

--- a/src/main/java/com/kusher/kusher_in_korea/auth/dto/LoginDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/dto/LoginDto.java
@@ -5,6 +5,6 @@ import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-public class RequestUserDto { // 회원가입 및 로그인 요청
+public class LoginDto { // 로그인 요청
     private String userEmail; // 유저이메일
 }

--- a/src/main/java/com/kusher/kusher_in_korea/auth/dto/UpdateUserDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/dto/UpdateUserDto.java
@@ -1,0 +1,14 @@
+package com.kusher.kusher_in_korea.auth.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@NoArgsConstructor
+public class UpdateUserDto {
+    private String userName; // 유저이름
+    private String userPhone; // 유저전화번호
+    private MultipartFile profileImage; // 유저 프로필 이미지 파일
+    private String userAddress; // 유저 주소
+}

--- a/src/main/java/com/kusher/kusher_in_korea/auth/dto/UserDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/dto/UserDto.java
@@ -9,12 +9,20 @@ import lombok.NoArgsConstructor;
 public class UserDto {
 
     private Long id; // 유저번호
+    private String userName; // 유저이름
     private String userEmail; // 유저이메일
+    private String userPhone; // 유저전화번호
+    private String profileImage; // 유저 프로필 이미지
+    private String userAddress; // 유저 주소
     private String userType; // 유저유형 (일반유저 or 식당주인)
 
     public UserDto(User user){
         this.id = user.getId();
+        this.userName = user.getUserName();
         this.userEmail = user.getUserEmail();
+        this.userPhone = user.getUserPhone();
+        this.profileImage = user.getProfileImage();
+        this.userAddress = user.getUserAddress();
         this.userType = user.getUserType();
     }
 }

--- a/src/main/java/com/kusher/kusher_in_korea/auth/service/UserService.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/service/UserService.java
@@ -1,6 +1,8 @@
 package com.kusher.kusher_in_korea.auth.service;
 
-import com.kusher.kusher_in_korea.auth.dto.RequestUserDto;
+import com.kusher.kusher_in_korea.auth.dto.CreateUserDto;
+import com.kusher.kusher_in_korea.auth.dto.LoginDto;
+import com.kusher.kusher_in_korea.auth.dto.UpdateUserDto;
 import com.kusher.kusher_in_korea.ingredient.domain.Cart;
 import com.kusher.kusher_in_korea.ingredient.dto.response.CartDto;
 import com.kusher.kusher_in_korea.ingredient.repository.CartRepository;
@@ -31,9 +33,9 @@ public class UserService {
 
     // 유저 추가
     @Transactional
-    public Long createUser(RequestUserDto userDto) {
+    public Long createUser(CreateUserDto userDto, String imageUrl) {
         ValidationDuplicateUser(userDto.getUserEmail());
-        User user = User.createUser(userDto);
+        User user = User.createUser(userDto.getUserName(), userDto.getUserEmail(), userDto.getUserPhone(), imageUrl, userDto.getUserAddress());
         Cart cart = Cart.createCart(user); // 유저 생성 시 유저가 사용할 장바구니도 생성
         Long id = userRepository.save(user).getId();
         cartRepository.save(cart);
@@ -49,9 +51,23 @@ public class UserService {
     }
 
     // 로그인
-    public UserDto login(RequestUserDto userDto) {
+    public UserDto login(LoginDto userDto) {
         User user = userRepository.findByUserEmail(userDto.getUserEmail()).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
         return new UserDto(user);
+    }
+
+    // 이 이메일로 로그인한 적이 있는지 유무 판정
+    public boolean checkLogin(String userEmail) {
+        Optional<User> findUsers = userRepository.findByUserEmail(userEmail);
+        return findUsers.isPresent();
+    }
+
+    // 유저 정보 수정
+    @Transactional
+    public Long updateUser(Long userId, UpdateUserDto userDto, String imageUrl) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
+        user.updateUser(userDto.getUserName(), userDto.getUserPhone(), imageUrl, userDto.getUserAddress());
+        return user.getId();
     }
 
     // 유저 정보 조회

--- a/src/main/java/com/kusher/kusher_in_korea/auth/service/UserService.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/service/UserService.java
@@ -53,13 +53,14 @@ public class UserService {
     // 로그인
     public UserDto login(LoginDto userDto) {
         User user = userRepository.findByUserEmail(userDto.getUserEmail()).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
+        user.setNotFirstLogin(); // 이제 첫 로그인이 아님
         return new UserDto(user);
     }
 
     // 이 이메일로 로그인한 적이 있는지 유무 판정
     public boolean checkLogin(String userEmail) {
         Optional<User> findUsers = userRepository.findByUserEmail(userEmail);
-        return findUsers.isPresent();
+        return findUsers.map(User::isFirstLogin).orElse(false); // 첫 로그인이면 true, 아니면 false
     }
 
     // 유저 정보 수정


### PR DESCRIPTION
- [x] User 객체에 이름, 전화번호, 주소 등 정보 추가, 프로필 사진 적용
- [x] 회원가입 객체 CreateUserDto 추가
- [x] 유저수정 객체 UpdateUserDto 추가
- [x] 응답 객체 UserDto에 추가적인 정보 반영
- [x] 유저정보 수정 API 추가
- [x] 이메일로 로그인 이력 확인 API 추가