### PR TITLE
[refactor] #51 코드리뷰 피드백 반영 및 일부 API 반환값 수정

### DIFF
--- a/src/main/java/com/kusher/kusher_in_korea/auth/controller/UserController.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/controller/UserController.java
@@ -34,7 +34,7 @@ public class UserController {
     @PostMapping("/create")
     public ApiResponse<Long> createUser(CreateUserDto userDto) throws IOException {
         String imageUrl = "";
-        if(userDto.getProfileImage() != null) {
+        if (userDto.getProfileImage() != null) {
             imageUrl = imageUploadService.uploadImage(userDto.getProfileImage());
         }
         Long userId = userService.createUser(userDto, imageUrl);
@@ -66,7 +66,7 @@ public class UserController {
     @PutMapping("/{userId}")
     public ApiResponse<Long> updateUser(@PathVariable Long userId, UpdateUserDto userDto) throws IOException {
         String imageUrl = "";
-        if(userDto.getProfileImage() != null) {
+        if (userDto.getProfileImage() != null) {
             imageUrl = imageUploadService.uploadImage(userDto.getProfileImage());
         }
         Long updateUserId = userService.updateUser(userId, userDto, imageUrl);

--- a/src/main/java/com/kusher/kusher_in_korea/auth/domain/User.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/domain/User.java
@@ -31,7 +31,7 @@ public class User {
 
     private boolean isFirstLogin; // 첫 로그인 여부
 
-    @OneToOne(fetch = FetchType.LAZY , cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     @JoinColumn(name = "cart_id")
     private Cart cart; // 유저와 장바구니는 일대일 관계
 
@@ -60,7 +60,7 @@ public class User {
         this.cart = cart;
     }
 
-    public void setNotFirstLogin(){
+    public void setNotFirstLogin() {
         this.isFirstLogin = false;
     }
 }

--- a/src/main/java/com/kusher/kusher_in_korea/auth/dto/CreateUserDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/dto/CreateUserDto.java
@@ -1,12 +1,13 @@
 package com.kusher.kusher_in_korea.auth.dto;
 
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class CreateUserDto { // 신규 회원가입 요청
+
     private String userName; // 유저이름
     private String userEmail; // 유저이메일
     private String userPhone; // 유저전화번호

--- a/src/main/java/com/kusher/kusher_in_korea/auth/dto/LoginDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/dto/LoginDto.java
@@ -1,10 +1,11 @@
 package com.kusher.kusher_in_korea.auth.dto;
 
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class LoginDto { // 로그인 요청
+
     private String userEmail; // 유저이메일
 }

--- a/src/main/java/com/kusher/kusher_in_korea/auth/dto/UpdateUserDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/dto/UpdateUserDto.java
@@ -1,12 +1,13 @@
 package com.kusher.kusher_in_korea.auth.dto;
 
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class UpdateUserDto {
+
     private String userName; // 유저이름
     private String userPhone; // 유저전화번호
     private MultipartFile profileImage; // 유저 프로필 이미지 파일

--- a/src/main/java/com/kusher/kusher_in_korea/auth/dto/UserDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/dto/UserDto.java
@@ -1,11 +1,9 @@
 package com.kusher.kusher_in_korea.auth.dto;
 
 import com.kusher.kusher_in_korea.auth.domain.User;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
-@Data
-@NoArgsConstructor
+@Getter
 public class UserDto {
 
     private Long id; // 유저번호
@@ -16,7 +14,7 @@ public class UserDto {
     private String userAddress; // 유저 주소
     private String userType; // 유저유형 (일반유저 or 식당주인)
 
-    public UserDto(User user){
+    public UserDto(User user) {
         this.id = user.getId();
         this.userName = user.getUserName();
         this.userEmail = user.getUserEmail();

--- a/src/main/java/com/kusher/kusher_in_korea/auth/repository/UserRepository.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/repository/UserRepository.java
@@ -14,5 +14,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findByIdAndUserType(Long id, String userType);
     
     // 중복 회원가입 방지
+    boolean existsByUserEmail(String userEmail);
+
+    // 유저 이메일로 유저 찾기
     Optional<User> findByUserEmail(String userEmail);
 }

--- a/src/main/java/com/kusher/kusher_in_korea/auth/service/UserService.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/service/UserService.java
@@ -44,8 +44,7 @@ public class UserService {
 
     // 유저명 중복 방지
     public void ValidationDuplicateUser(String userEmail) {
-        Optional<User> findUsers = userRepository.findByUserEmail(userEmail);
-        if (findUsers.isPresent()) {
+        if (userRepository.existsByUserEmail(userEmail)) {
             throw new CustomException(ResponseCode.DUPLICATED_USER);
         }
     }
@@ -60,20 +59,20 @@ public class UserService {
     // 이 이메일로 로그인한 적이 있는지 유무 판정
     public boolean checkLogin(String userEmail) {
         Optional<User> findUsers = userRepository.findByUserEmail(userEmail);
-        return findUsers.map(User::isFirstLogin).orElse(false); // 첫 로그인이면 true, 아니면 false
+        return findUsers.map(User::isFirstLogin).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
     }
 
     // 유저 정보 수정
     @Transactional
     public Long updateUser(Long userId, UpdateUserDto userDto, String imageUrl) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
+        User user = getUserById(userId);
         user.updateUser(userDto.getUserName(), userDto.getUserPhone(), imageUrl, userDto.getUserAddress());
         return user.getId();
     }
 
     // 유저 정보 조회
     public UserDto getUser(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
+        User user = getUserById(userId);
         return new UserDto(user);
     }
 
@@ -85,8 +84,12 @@ public class UserService {
 
     // 유저의 장바구니 조회
     public CartDto getUserCart(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
+        User user = getUserById(userId);
         return new CartDto(user.getCart());
+    }
+
+    public User getUserById(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/kusher/kusher_in_korea/auth/service/UserService.java
+++ b/src/main/java/com/kusher/kusher_in_korea/auth/service/UserService.java
@@ -23,8 +23,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserService {
 
     private final UserRepository userRepository;

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/domain/Cart.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/domain/Cart.java
@@ -19,7 +19,7 @@ public class Cart { // User와 장바구니는 일대일 관계
     @Column(name = "cart_id")
     private Long id;
 
-    @OneToOne(mappedBy = "cart", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "cart", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private User user; // 장바구니를 소유한 회원
 
     @OneToMany(mappedBy = "cart", cascade = {CascadeType.REMOVE}, orphanRemoval = true) // orphanRemoval: 장바구니에서 재료를 삭제하면 DB에서도 삭제

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/domain/Cart.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/domain/Cart.java
@@ -14,15 +14,16 @@ import java.util.List;
 @Table(name = "cart")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Cart { // User와 장바구니는 일대일 관계
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "cart_id")
     private Long id;
 
-    @OneToOne(mappedBy = "cart", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "cart", fetch = FetchType.LAZY)
     private User user; // 장바구니를 소유한 회원
 
-    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true) // orphanRemoval: 장바구니에서 재료를 삭제하면 DB에서도 삭제
-    private List<CartIngredient> cartIngredients = new ArrayList<>(); // 장바구니에 담긴 재료들
+    @OneToMany(mappedBy = "cart", cascade = {CascadeType.REMOVE}, orphanRemoval = true) // orphanRemoval: 장바구니에서 재료를 삭제하면 DB에서도 삭제
+    private List<CartIngredient> cartIngredients = new ArrayList<>(); // 장바구니에 담긴 상품들
 
     // 생성 메서드
     public static Cart createCart(User user) {

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/domain/CartIngredient.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/domain/CartIngredient.java
@@ -11,6 +11,7 @@ import javax.persistence.*;
 @Table(name = "cart_ingredient")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CartIngredient { // 장바구니와 식재료의 다대다 관계로 인한 중간 테이블
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "cart_ingredient_id")
     private Long id;

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/domain/Category.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/domain/Category.java
@@ -1,6 +1,8 @@
 package com.kusher.kusher_in_korea.ingredient.domain;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -9,7 +11,9 @@ import java.util.List;
 @Entity
 @Getter
 @Table(name = "category")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Category {
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "category_id")
     private Long id;

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/domain/Delivery.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/domain/Delivery.java
@@ -1,7 +1,9 @@
 package com.kusher.kusher_in_korea.ingredient.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
@@ -11,6 +13,7 @@ import static javax.persistence.FetchType.LAZY;
 @Entity
 @Getter @Setter
 @Table(name = "delivery")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Delivery {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -35,4 +38,3 @@ public class Delivery {
         return delivery;
     }
 }
-

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/domain/Ingredient.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/domain/Ingredient.java
@@ -11,6 +11,7 @@ import javax.persistence.*;
 @Table(name = "ingredient")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Ingredient { // 식재료 테이블
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "ingredient_id")
     private Long id;

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/domain/Orders.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/domain/Orders.java
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.kusher.kusher_in_korea.auth.domain.User;
 import com.kusher.kusher_in_korea.util.exception.CustomException;
 import com.kusher.kusher_in_korea.util.exception.ResponseCode;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -15,7 +17,9 @@ import java.util.List;
 @Entity
 @Getter
 @Table(name = "orders")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Orders { // 주문은 유저와 일대다 관계
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -28,10 +32,10 @@ public class Orders { // 주문은 유저와 일대다 관계
 
     private LocalDateTime orderDateTime; // 주문 날짜 및 시간
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.REMOVE})
     private Delivery delivery; // 주문과 배송은 일대일 관계
 
-    @OneToMany(mappedBy = "orders", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "orders", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private List<OrdersIngredient> ordersIngredientList = new ArrayList<>(); // 주문과 주문상품은 일대다 관계
 
     public void update(Delivery delivery) {

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/domain/OrdersIngredient.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/domain/OrdersIngredient.java
@@ -1,13 +1,17 @@
 package com.kusher.kusher_in_korea.ingredient.domain;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
 @Table(name = "orders_ingredient")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrdersIngredient {
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "order_ingredient_id")
     private Long id;

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/request/AddCartIngredientDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/request/AddCartIngredientDto.java
@@ -1,11 +1,12 @@
 package com.kusher.kusher_in_korea.ingredient.dto.request;
 
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class AddCartIngredientDto { // 장바구니에 재료 추가 요청
+
     private Long cartId;
     private Long ingredientId;
     private int count;

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/request/AddCartIngredientDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/request/AddCartIngredientDto.java
@@ -10,4 +10,8 @@ public class AddCartIngredientDto { // 장바구니에 재료 추가 요청
     private Long cartId;
     private Long ingredientId;
     private int count;
+
+    public void setCartId(Long cartId) {
+        this.cartId = cartId;
+    }
 }

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/request/CancelOrdersDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/request/CancelOrdersDto.java
@@ -1,10 +1,11 @@
 package com.kusher.kusher_in_korea.ingredient.dto.request;
 
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class CancelOrdersDto { // 주문 취소 기능
+
     private Long orderId;
 }

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/request/ChangeAddressDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/request/ChangeAddressDto.java
@@ -1,13 +1,13 @@
 package com.kusher.kusher_in_korea.ingredient.dto.request;
 
 import com.kusher.kusher_in_korea.ingredient.domain.Address;
-import com.kusher.kusher_in_korea.ingredient.dto.response.DeliveryDto;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class ChangeAddressDto { // 배송지 변경 기능
+
     private Long deliveryId;
     private Long userId;
     private Address address;

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/request/CreateIngredientDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/request/CreateIngredientDto.java
@@ -1,12 +1,14 @@
 package com.kusher.kusher_in_korea.ingredient.dto.request;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
-@Setter
+@NoArgsConstructor
 public class CreateIngredientDto {
+
     private String ingredientName;
     private String ingredientCategory;
     private MultipartFile ingredientImage; // This is the image file that will be uploaded to S3

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/request/CreateOrdersDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/request/CreateOrdersDto.java
@@ -4,13 +4,15 @@ import com.kusher.kusher_in_korea.ingredient.domain.Address;
 import com.kusher.kusher_in_korea.ingredient.domain.OrderStatus;
 import com.kusher.kusher_in_korea.ingredient.dto.response.CartIngredientDto;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class CreateOrdersDto {
+
     private Long userId;
     private OrderStatus orderStatus;
     private Address address;

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/request/RequestCategoryDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/request/RequestCategoryDto.java
@@ -1,10 +1,11 @@
 package com.kusher.kusher_in_korea.ingredient.dto.request;
 
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class RequestCategoryDto { // 신규 식재료 카테고리 생성 기능
+
     private String categoryName;
 }

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/request/RequestIngredientDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/request/RequestIngredientDto.java
@@ -1,11 +1,12 @@
 package com.kusher.kusher_in_korea.ingredient.dto.request;
 
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class RequestIngredientDto { // 식재료 생성/수정 기능
+
     private String ingredientName;
     private String ingredientCategory;
     private String ingredientImage;

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/response/CartDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/response/CartDto.java
@@ -1,16 +1,15 @@
 package com.kusher.kusher_in_korea.ingredient.dto.response;
 
 import com.kusher.kusher_in_korea.ingredient.domain.Cart;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Data
-@NoArgsConstructor
+@Getter
 public class CartDto { // 장바구니 조회 요청에 대한 응답
+
     private Long cartId;
     private Long userId;
     private List<CartIngredientDto> cartIngredients = new ArrayList<>();

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/response/CartIngredientDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/response/CartIngredientDto.java
@@ -1,12 +1,11 @@
 package com.kusher.kusher_in_korea.ingredient.dto.response;
 
 import com.kusher.kusher_in_korea.ingredient.domain.CartIngredient;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
-@Data
-@NoArgsConstructor
+@Getter
 public class CartIngredientDto {
+
     private Long cartIngredientId;
     private String ingredientName;
     private String ingredientImage;

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/response/CategoryDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/response/CategoryDto.java
@@ -1,14 +1,14 @@
 package com.kusher.kusher_in_korea.ingredient.dto.response;
 
 import com.kusher.kusher_in_korea.ingredient.domain.Category;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
-@Data
-@NoArgsConstructor
+@Getter
 public class CategoryDto {
+
     private Long CategoryId;
     private String categoryName;
+
     public CategoryDto(Category category) {
         this.CategoryId = category.getId();
         this.categoryName = category.getName();

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/response/DeliveryDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/response/DeliveryDto.java
@@ -1,12 +1,11 @@
 package com.kusher.kusher_in_korea.ingredient.dto.response;
 
 import com.kusher.kusher_in_korea.ingredient.domain.Delivery;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
-@Data
-@NoArgsConstructor
+@Getter
 public class DeliveryDto {
+
     private Long deliveryId;
     private String city;
     private String street;

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/response/IngredientDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/response/IngredientDto.java
@@ -1,12 +1,11 @@
 package com.kusher.kusher_in_korea.ingredient.dto.response;
 
 import com.kusher.kusher_in_korea.ingredient.domain.Ingredient;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
-@Data
-@NoArgsConstructor
+@Getter
 public class IngredientDto {
+
     private Long ingredientId;
     private String ingredientName;
     private String ingredientImage;

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/response/OrdersDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/response/OrdersDto.java
@@ -2,16 +2,15 @@ package com.kusher.kusher_in_korea.ingredient.dto.response;
 
 import com.kusher.kusher_in_korea.ingredient.domain.Orders;
 import com.kusher.kusher_in_korea.ingredient.domain.OrdersIngredient;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-@Data
-@NoArgsConstructor
+@Getter
 public class OrdersDto { // 주문 조회에 대한 응답
+
     private Long orderId;
     private String orderStatus;
     private DeliveryDto delivery;

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/response/OrdersIngredientDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/dto/response/OrdersIngredientDto.java
@@ -1,12 +1,11 @@
 package com.kusher.kusher_in_korea.ingredient.dto.response;
 
 import com.kusher.kusher_in_korea.ingredient.domain.OrdersIngredient;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
-@Data
-@NoArgsConstructor
+@Getter
 public class OrdersIngredientDto {
+
     private Long orderIngredientId;
     private String ingredientName;
     private String ingredientImage;

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/repository/CategoryRepository.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/repository/CategoryRepository.java
@@ -18,4 +18,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     // 이름으로 카테고리 조회
     Optional<Category> findByName(String name);
+
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/repository/IngredientRepository.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/repository/IngredientRepository.java
@@ -22,4 +22,6 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> { 
     Optional<Ingredient> findById(Long id);
 
     Page<Ingredient> findAllByCategoryId(Long categoryId, Pageable pageable);
+
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/service/IngredientService.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/service/IngredientService.java
@@ -76,9 +76,8 @@ public class IngredientService { // 식재료 및 카테고리를 제어한다.
 
     // 중복 식재료명 감지
     private void validateDuplicateIngredient(String name) {
-        ingredientRepository.findByName(name).ifPresent(m -> {
-            throw new IllegalStateException("이미 존재하는 식재료입니다.");
-        });
+        if (ingredientRepository.existsByName(name))
+            throw new IllegalStateException(ResponseCode.DUPLICATED_INGREDIENT.getMessage());
     }
 
     // 식재료 수정
@@ -107,9 +106,8 @@ public class IngredientService { // 식재료 및 카테고리를 제어한다.
 
     // 중복 카테고리 감지
     private void validateDuplicateCategory(String name) {
-        categoryRepository.findByName(name).ifPresent(m -> {
-            throw new CustomException(ResponseCode.CATEGORY_NOT_FOUND);
-        });
+        if (categoryRepository.existsByName(name))
+            throw new IllegalStateException(ResponseCode.DUPLICATED_CATEGORY.getMessage());
     }
 
     // 카테고리 수정

--- a/src/main/java/com/kusher/kusher_in_korea/ingredient/service/OrdersService.java
+++ b/src/main/java/com/kusher/kusher_in_korea/ingredient/service/OrdersService.java
@@ -91,15 +91,16 @@ public class OrdersService {
     // 주문 취소
     @Transactional
     public void cancelOrder(Long orderId) {
-        Orders order = ordersRepository.findById(orderId).orElseThrow(() -> new CustomException(ResponseCode.ORDERS_NOT_FOUND));
+        Orders order = getOrderById(orderId);
         order.cancel();
     }
 
     // 주문 수정(배송지 수정)
     @Transactional
     public Long updateOrder(Long orderId, ChangeAddressDto changeAddressDto) {
-        Orders order = ordersRepository.findById(orderId).orElseThrow(() -> new CustomException(ResponseCode.ORDERS_NOT_FOUND));
-        if(!Objects.equals(order.getUser().getId(), changeAddressDto.getUserId())) throw new CustomException(ResponseCode.USER_NOT_FOUND);
+        Orders order = getOrderById(orderId);
+        if (!Objects.equals(order.getUser().getId(), changeAddressDto.getUserId()))
+            throw new CustomException(ResponseCode.USER_NOT_FOUND);
         order.getDelivery().setAddress(changeAddressDto.getAddress());
         return order.getId();
     }
@@ -112,7 +113,7 @@ public class OrdersService {
 
     // 특정 주문 조회
     public OrdersDto getOrder(Long orderId) {
-        Orders order = ordersRepository.findById(orderId).orElseThrow(() -> new CustomException(ResponseCode.ORDERS_NOT_FOUND));
+        Orders order = getOrderById(orderId);
         return new OrdersDto(order);
     }
 
@@ -122,4 +123,11 @@ public class OrdersService {
         return orders.stream().map(OrdersDto::new).collect(Collectors.toList());
     }
 
+    public Orders getOrderById(Long orderId) {
+        return ordersRepository.findById(orderId).orElseThrow(() -> new CustomException(ResponseCode.ORDERS_NOT_FOUND));
+    }
+
+    public CartIngredient getCartIngredientById(Long cartIngredientId) {
+        return cartIngredientRepository.findById(cartIngredientId).orElseThrow(() -> new CustomException(ResponseCode.CART_INGREDIENT_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/kusher/kusher_in_korea/payment/Repository/PaymentRepository.java
+++ b/src/main/java/com/kusher/kusher_in_korea/payment/Repository/PaymentRepository.java
@@ -15,7 +15,7 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     //결제정보 저장
     @Modifying
-    @Query(value ="INSERT INTO payment (payment_id, user_id, pay_uid, pay_amount, pay_method,pay_card_name) " +
+    @Query(value = "INSERT INTO payment (payment_id, user_id, pay_uid, pay_amount, pay_method,pay_card_name) " +
             "VALUES (:payment_id, :user_id, :pay_uid, :pay_amount, :pay_method, :pay_card_name)", nativeQuery = true)
     List<Payment> insertPaymentInfo(
             @Param("payment_id") String id,
@@ -27,13 +27,13 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     );
 
     //결제정보 조회
-    @Query(value = "select * FROM payment p WHERE p.payment_id = :payment_id",nativeQuery = true)
+    @Query(value = "select * FROM payment p WHERE p.payment_id = :payment_id", nativeQuery = true)
     Payment selectPaymentInfo(
             @Param("payment_id") String id
     );
 
     //결제유저정보 조회
-    @Query(value = "SELECT * FROM user u WHERE u.user_id = :user_id",nativeQuery = true)
+    @Query(value = "SELECT * FROM user u WHERE u.user_id = :user_id", nativeQuery = true)
     User selectUserInfo(
             @Param("user_id") Long id
     );

--- a/src/main/java/com/kusher/kusher_in_korea/payment/controller/PaymentController.java
+++ b/src/main/java/com/kusher/kusher_in_korea/payment/controller/PaymentController.java
@@ -40,29 +40,29 @@ public class PaymentController { // 결제 API 연동을 위한 Controller
     private String apiSecret;
 
     @Autowired
-    public PaymentController(PaymentService paymentService,OrdersService ordersService) {
-        this.api = new IamportClient(apiKey,apiSecret);
+    public PaymentController(PaymentService paymentService, OrdersService ordersService) {
+        this.api = new IamportClient(apiKey, apiSecret);
         this.paymentService = paymentService;
         this.ordersService = ordersService;
     }
 
     // 구매 창 GET
     @GetMapping("/payment")
-    public String paymentPage(Long orderId,HttpSession session, Model model) throws PaymentException {
+    public String paymentPage(Long orderId, HttpSession session, Model model) throws PaymentException {
         log.trace("paymentPage() invoked");
 
-        try{
+        try {
             OrdersDto order = this.ordersService.getOrder(orderId);
 
             User owner = (User) session.getAttribute("__LOGIN__");
 
-            if(owner != null) {
+            if (owner != null) {
                 User user = this.paymentService.getPayUserInfo(owner.getId());
                 model.addAttribute("__USER__", user);
             }
 
             Objects.requireNonNull(order);
-            model.addAttribute("__ORDER__",order);
+            model.addAttribute("__ORDER__", order);
         } catch (Exception e) {
             throw new PaymentException(e);
         }
@@ -77,7 +77,7 @@ public class PaymentController { // 결제 API 연동을 위한 Controller
             @PathVariable(value = "imp_uid") String imp_uid,
             String orderId,
             Long userId) throws IamportResponseException, IOException, PaymentException {
-        log.trace("paymentByImpUid({},{},{}) invoked.",imp_uid,orderId,userId);
+        log.trace("paymentByImpUid({},{},{}) invoked.", imp_uid, orderId, userId);
 
         payApiResponse response = new payApiResponse();
         String result = "";
@@ -86,11 +86,11 @@ public class PaymentController { // 결제 API 연동을 위한 Controller
         //결제 완료 후 DB조작 메서드 실행
         try {
             switch (payment.getStatus()) {
-                case "paid" :
-                    result = this.paymentService.savePayment(payment,userId);
+                case "paid":
+                    result = this.paymentService.savePayment(payment, userId);
 
                     break;
-                case "failed" :
+                case "failed":
                     result = "FAIL:04";
 
                     break;
@@ -98,7 +98,7 @@ public class PaymentController { // 결제 API 연동을 위한 Controller
 
             response.add("result", result);
             response.add("payment_id", payment.getMerchantUid());
-        }catch (PaymentException e) {
+        } catch (PaymentException e) {
             throw new PaymentException(e);
         }
 
@@ -117,9 +117,9 @@ public class PaymentController { // 결제 API 연동을 위한 Controller
     @ResponseBody
     @PostMapping("/refund/{imp_uid}")
     public IamportResponse<Payment> cancelPaymentByImpUid(
-            @PathVariable(value = "imp_uid")String imp_uid,
+            @PathVariable(value = "imp_uid") String imp_uid,
             CancelData cancelData) throws PaymentException {
-        log.trace("cancelPaymentByImpUid({},{}) invoked.", imp_uid,cancelData);
+        log.trace("cancelPaymentByImpUid({},{}) invoked.", imp_uid, cancelData);
 
         return null;
     }

--- a/src/main/java/com/kusher/kusher_in_korea/payment/domain/Payment.java
+++ b/src/main/java/com/kusher/kusher_in_korea/payment/domain/Payment.java
@@ -10,8 +10,8 @@ import javax.persistence.*;
 @Setter
 @Table(name = "payment")
 public class Payment {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "order_number")
     private Long order_id; //결제 개수
 
@@ -28,4 +28,3 @@ public class Payment {
 
     private String payCardName; //카드이름
 }
-

--- a/src/main/java/com/kusher/kusher_in_korea/payment/dto/PaymentDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/payment/dto/PaymentDto.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class PaymentDto {
+
     private String id; //결제번호
     private Long userId; //예약 유저 번호
     private String payUid; //결제한 곳 uid

--- a/src/main/java/com/kusher/kusher_in_korea/payment/payApiResponse.java
+++ b/src/main/java/com/kusher/kusher_in_korea/payment/payApiResponse.java
@@ -13,7 +13,6 @@ import lombok.Setter;
 @Setter
 public class payApiResponse {
 
-
     @ApiModelProperty(example = "상태코드")
     private int status;
 

--- a/src/main/java/com/kusher/kusher_in_korea/reviewfeedback/domain/Feedback.java
+++ b/src/main/java/com/kusher/kusher_in_korea/reviewfeedback/domain/Feedback.java
@@ -1,7 +1,9 @@
 package com.kusher.kusher_in_korea.reviewfeedback.domain;
 
 import com.kusher.kusher_in_korea.auth.domain.User;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -9,6 +11,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Table(name = "feedback")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Feedback {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/kusher/kusher_in_korea/reviewfeedback/domain/Review.java
+++ b/src/main/java/com/kusher/kusher_in_korea/reviewfeedback/domain/Review.java
@@ -3,7 +3,9 @@ package com.kusher.kusher_in_korea.reviewfeedback.domain;
 import com.kusher.kusher_in_korea.auth.domain.User;
 import com.kusher.kusher_in_korea.reviewfeedback.dto.CreateReviewDto;
 import com.kusher.kusher_in_korea.tabling.domain.Restaurant;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -11,7 +13,9 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Table(name = "review")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Review {
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "review_id")
     private Long id; // 평가번호
@@ -43,5 +47,4 @@ public class Review {
         review.reviewDateTime = LocalDateTime.now();
         return review;
     }
-
 }

--- a/src/main/java/com/kusher/kusher_in_korea/reviewfeedback/dto/CreateFeedbackDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/reviewfeedback/dto/CreateFeedbackDto.java
@@ -1,11 +1,12 @@
 package com.kusher.kusher_in_korea.reviewfeedback.dto;
 
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class CreateFeedbackDto { // 앱 개발자들에게 피드백을 전송할 목적, 그러므로 FeedbackDto는 필요없음
+
     private Long userId; // 유저번호
     private String feedbackContent; // 피드백 내용
 }

--- a/src/main/java/com/kusher/kusher_in_korea/reviewfeedback/dto/CreateReviewDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/reviewfeedback/dto/CreateReviewDto.java
@@ -1,12 +1,13 @@
 package com.kusher.kusher_in_korea.reviewfeedback.dto;
 
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class CreateReviewDto { // 평가 생성 요청
+
     private Long userId; // 유저번호
     private Long restaurantId; // 식당번호
     private MultipartFile reviewImage; // 식당이미지

--- a/src/main/java/com/kusher/kusher_in_korea/reviewfeedback/dto/ReviewDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/reviewfeedback/dto/ReviewDto.java
@@ -1,14 +1,13 @@
 package com.kusher.kusher_in_korea.reviewfeedback.dto;
 
 import com.kusher.kusher_in_korea.reviewfeedback.domain.Review;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-@Data
-@NoArgsConstructor
+@Getter
 public class ReviewDto { // 식당별 평가, 내가 한 평가 등을 클라이언트에게 전송할 목적
+
     private Long reviewId; // 평가번호
     private Long userId; // 유저번호
     private Long restaurantId; // 식당번호
@@ -26,5 +25,4 @@ public class ReviewDto { // 식당별 평가, 내가 한 평가 등을 클라이
         this.reviewTime = review.getReviewDateTime();
         this.reviewRating = review.getRating();
     }
-
 }

--- a/src/main/java/com/kusher/kusher_in_korea/reviewfeedback/repository/ReviewRepository.java
+++ b/src/main/java/com/kusher/kusher_in_korea/reviewfeedback/repository/ReviewRepository.java
@@ -1,6 +1,7 @@
 package com.kusher.kusher_in_korea.reviewfeedback.repository;
 
 import com.kusher.kusher_in_korea.reviewfeedback.domain.Review;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,8 +16,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findByUserId(Long userId);
 
     // 특정 유저가 이미 특정 식당에 평가를 남겼는지 확인
-    List<Review> findByUserIdAndRestaurantId(Long userId, Long restaurantId);
+    boolean existsByUserIdAndRestaurantId(Long userId, Long restaurantId);
 
     // 평가 삭제
-    void deleteById(Long reviewId);
+    void deleteById(@NotNull Long reviewId);
 }

--- a/src/main/java/com/kusher/kusher_in_korea/reviewfeedback/service/FeedbackService.java
+++ b/src/main/java/com/kusher/kusher_in_korea/reviewfeedback/service/FeedbackService.java
@@ -15,8 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class FeedbackService {
 
     private final FeedbackRepository feedbackRepository;
@@ -35,6 +35,5 @@ public class FeedbackService {
     public List<Feedback> getAllFeedbacks() {
         return feedbackRepository.findAll();
     }
-
 }
 

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/controller/ReservationController.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/controller/ReservationController.java
@@ -3,16 +3,19 @@ package com.kusher.kusher_in_korea.tabling.controller;
 import com.kusher.kusher_in_korea.tabling.dto.request.CreateReservationDto;
 import com.kusher.kusher_in_korea.tabling.dto.request.UpdateReservationDto;
 import com.kusher.kusher_in_korea.tabling.dto.response.ReservationDto;
-import com.kusher.kusher_in_korea.tabling.service.ReservationService;import com.kusher.kusher_in_korea.util.api.ApiResponse;
+import com.kusher.kusher_in_korea.tabling.service.ReservationService;
+import com.kusher.kusher_in_korea.util.api.ApiResponse;
 import com.kusher.kusher_in_korea.util.exception.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/reservation")
 public class ReservationController {
+
     private final ReservationService reservationService;
 
     // 전체 예약 조회 (관리자용)

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/controller/ReservationController.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/controller/ReservationController.java
@@ -27,9 +27,9 @@ public class ReservationController {
 
     // 예약 생성
     @PostMapping
-    public ApiResponse<Long> createReservations(@RequestBody CreateReservationDto createReservationDto) {
-        Long id = reservationService.createReservation(createReservationDto);
-        return ApiResponse.success(id, ResponseCode.RESERVATION_CREATE_SUCCESS.getMessage());
+    public ApiResponse<ReservationDto> createReservations(@RequestBody CreateReservationDto createReservationDto) {
+        ReservationDto reservationDto = reservationService.createReservation(createReservationDto);
+        return ApiResponse.success(reservationDto, ResponseCode.RESERVATION_CREATE_SUCCESS.getMessage());
     }
 
     // 예약 수정

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/controller/RestaurantController.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/controller/RestaurantController.java
@@ -21,6 +21,7 @@ import java.util.List;
 @RequestMapping("/api/restaurant")
 @RequiredArgsConstructor
 public class RestaurantController {
+
     private final RestaurantService restaurantService;
     private final ReviewService reviewService;
     private final ReservationService reservationService;

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/domain/Reservation.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/domain/Reservation.java
@@ -16,8 +16,7 @@ import java.time.LocalTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Reservation {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "reservation_id")
     private Long id; // 예약번호
 
@@ -25,7 +24,7 @@ public class Reservation {
     @JoinColumn(name = "user_id")
     private User user; // 예약자(유저번호)
 
-    @ManyToOne(fetch = FetchType.LAZY) // 식당 - 예약은 1대다
+    @ManyToOne(fetch = FetchType.LAZY, cascade = {CascadeType.REMOVE}) // 식당 - 예약은 1대다, 식당이 사라지면 예약도 사라진다
     @JoinColumn(name = "restaurant_id")
     private Restaurant restaurant; // 식당(식당번호)
 

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/domain/Restaurant.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/domain/Restaurant.java
@@ -40,7 +40,7 @@ public class Restaurant {
 
     private String description; // 식당설명
 
-    @OneToMany(mappedBy = "restaurant", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "restaurant", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     private List<RestaurantMenu> restaurantMenus = new ArrayList<>(); // 식당메뉴
 
     // 생성 메서드

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/domain/RestaurantMenu.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/domain/RestaurantMenu.java
@@ -12,8 +12,7 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RestaurantMenu {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "restaurant_menu_id")
     private Long id; // 메뉴번호
 

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/dto/request/CreateReservationDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/dto/request/CreateReservationDto.java
@@ -1,15 +1,15 @@
 package com.kusher.kusher_in_korea.tabling.dto.request;
 
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class CreateReservationDto { // 예약 추가 요청
+
     private Long userId; // 예약자(유저번호)
     private Long restaurantId; // 식당(식당번호)
     private LocalDate reservationDate; // 예약날짜

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/dto/request/CreateRestaurantDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/dto/request/CreateRestaurantDto.java
@@ -1,16 +1,15 @@
 package com.kusher.kusher_in_korea.tabling.dto.request;
 
 import com.kusher.kusher_in_korea.tabling.domain.Restaurant;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.List;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class CreateRestaurantDto { // 식당 추가 요청
+
     private Long userId; // 식당주인(유저번호)
     private String location; // 식당위치
     private String restaurantName; // 식당이름

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/dto/request/CreateRestaurantMenuDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/dto/request/CreateRestaurantMenuDto.java
@@ -1,12 +1,13 @@
 package com.kusher.kusher_in_korea.tabling.dto.request;
 
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class CreateRestaurantMenuDto { // 식당 메뉴 추가 요청
+
     private Long ownerId; // 유저번호 (식당 주인임을 확인하기 위함)
     private String menuName; // 메뉴이름
     private int price; // 메뉴가격

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/dto/request/DeleteRestaurantMenuDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/dto/request/DeleteRestaurantMenuDto.java
@@ -1,11 +1,12 @@
 package com.kusher.kusher_in_korea.tabling.dto.request;
 
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class DeleteRestaurantMenuDto { // 식당 메뉴 삭제 요청
+
     private Long menuId; // 메뉴번호
     private Long ownerId; // 식당 주인임을 확인하기 위함
 }

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/dto/request/RequestReservationListDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/dto/request/RequestReservationListDto.java
@@ -1,10 +1,12 @@
 package com.kusher.kusher_in_korea.tabling.dto.request;
 
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class RequestReservationListDto {
+
     private Long userId; // 유저번호
 }

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/dto/request/UpdateReservationDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/dto/request/UpdateReservationDto.java
@@ -1,14 +1,15 @@
 package com.kusher.kusher_in_korea.tabling.dto.request;
 
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class UpdateReservationDto {
+
     private Long reservationId; // 예약번호
     private Long restaurantId; // 식당(식당번호)
     private LocalDate reservationDate; // 예약날짜

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/dto/request/UpdateRestaurantDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/dto/request/UpdateRestaurantDto.java
@@ -1,13 +1,14 @@
 package com.kusher.kusher_in_korea.tabling.dto.request;
 
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalTime;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class UpdateRestaurantDto {
+
     private Long Id; // 식당번호
     private Long userId; // 유저번호 (식당 주인임을 확인하기 위함)
     private String location; // 식당주소

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/dto/request/UpdateRestaurantMenuDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/dto/request/UpdateRestaurantMenuDto.java
@@ -1,11 +1,12 @@
 package com.kusher.kusher_in_korea.tabling.dto.request;
 
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class UpdateRestaurantMenuDto { // 식당 메뉴 수정 요청
+
     private Long menuId; // 메뉴번호
     private Long ownerId; // 유저번호 (식당 주인임을 확인하기 위함)
     private Long restaurantId; // 식당번호

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/dto/response/ReservationDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/dto/response/ReservationDto.java
@@ -1,15 +1,14 @@
 package com.kusher.kusher_in_korea.tabling.dto.response;
 
 import com.kusher.kusher_in_korea.tabling.domain.Reservation;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 
-@Data
-@NoArgsConstructor
+@Getter
 public class ReservationDto { // 예약 응답
+
     private Long id; // 예약번호
     private Long userId; // 예약자(유저번호)
     private Long restaurantId; // 식당(식당번호)

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/dto/response/RestaurantDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/dto/response/RestaurantDto.java
@@ -1,17 +1,14 @@
 package com.kusher.kusher_in_korea.tabling.dto.response;
 
-
 import com.kusher.kusher_in_korea.tabling.domain.Restaurant;
 import com.kusher.kusher_in_korea.tabling.domain.RestaurantMenu;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
-@Data
-@NoArgsConstructor
+@Getter
 public class RestaurantDto {
 
     private Long id; // 식당번호

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/dto/response/RestaurantMenuDto.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/dto/response/RestaurantMenuDto.java
@@ -1,22 +1,16 @@
 package com.kusher.kusher_in_korea.tabling.dto.response;
 
 import com.kusher.kusher_in_korea.tabling.domain.RestaurantMenu;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
-@Data
-@NoArgsConstructor
+@Getter
 public class RestaurantMenuDto {
+
     private Long id; // 메뉴번호
-
     private Long restaurantId; // 식당번호
-
     private String menuName; // 메뉴이름
-
     private int price; // 메뉴가격
-
     private String menuImage; // 메뉴이미지
-
     private String menuDescription; // 메뉴설명
 
     public RestaurantMenuDto(RestaurantMenu restaurantMenu) {

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/repository/RestaurantRepository.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/repository/RestaurantRepository.java
@@ -2,6 +2,7 @@ package com.kusher.kusher_in_korea.tabling.repository;
 
 import com.kusher.kusher_in_korea.tabling.domain.Restaurant;
 import com.kusher.kusher_in_korea.tabling.domain.RestaurantMenu;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -19,4 +20,6 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
             + "join r.restaurantMenus m "
             + "where r.id = :id")
     List<RestaurantMenu> getMenus(Pageable pageable, @Param("id") Long id);
+
+    boolean existsById(@NotNull Long id);
 }

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/service/ReservationService.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/service/ReservationService.java
@@ -95,7 +95,7 @@ public class ReservationService {
     public void cancelReservation(Long reservationId) {
         Reservation reservation = reservationRepository.findById(reservationId).orElseThrow(() -> new CustomException(ResponseCode.RESERVATION_NOT_FOUND));
         if(!reservation.isCancelable()) {
-            throw new IllegalStateException("이미 예약이 취소되었습니다.");
+            throw new CustomException(ResponseCode.ALREADY_CANCELED);
         }
         reservation.cancelReservation();
         reservationRepository.save(reservation);

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/service/RestaurantService.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/service/RestaurantService.java
@@ -35,7 +35,7 @@ public class RestaurantService {
 
     // 특정 식당의 정보 조회
     public RestaurantDto findRestaurant(Long restaurantId) {
-        Restaurant restaurant = restaurantRepository.findById(restaurantId).orElseThrow(() -> new CustomException(ResponseCode.RESTAURANT_NOT_FOUND));
+        Restaurant restaurant = getRestaurantById(restaurantId);
         return new RestaurantDto(restaurant);
     }
 
@@ -49,7 +49,7 @@ public class RestaurantService {
 
     // 요청한 유저가 식당 주인인지 확인
     public boolean isOwner(Long restaurantId, Long ownerId) {
-        Restaurant restaurant = restaurantRepository.findById(restaurantId).orElseThrow(() -> new CustomException(ResponseCode.RESTAURANT_NOT_FOUND));
+        Restaurant restaurant = getRestaurantById(restaurantId);
         Long id = restaurant.getOwnerId();
         return (id.equals(ownerId));
     }
@@ -57,7 +57,8 @@ public class RestaurantService {
     // 새 식당 추가 (점주 타입만 가능)
     @Transactional
     public Long saveRestaurant(CreateRestaurantDto createRestaurantDto) {
-        User user = userRepository.findById(createRestaurantDto.getUserId()).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
+        if (!userRepository.existsById(createRestaurantDto.getUserId()))
+            throw new CustomException(ResponseCode.USER_NOT_FOUND);
         /*if (!Objects.equals(user.getUserType(), "점주"))
             throw new CustomException(ResponseCode.NOT_RESTAURANT_OWNER);*/
         Restaurant restaurant = Restaurant.createRestaurant(createRestaurantDto);
@@ -71,7 +72,7 @@ public class RestaurantService {
         Long userId = restaurantDto.getUserId();
         if (!isOwner(restaurantId, userId)) throw new CustomException(ResponseCode.NOT_RESTAURANT_OWNER);
 
-        Restaurant restaurant = restaurantRepository.findById(restaurantId).orElseThrow(() -> new CustomException(ResponseCode.RESTAURANT_NOT_FOUND));
+        Restaurant restaurant = getRestaurantById(restaurantId);
         restaurant.updateRestaurant(restaurantDto);
         restaurantRepository.save(restaurant);
         return restaurant.getId();
@@ -80,7 +81,7 @@ public class RestaurantService {
     // 특정 식당 메뉴 추가
     @Transactional
     public Long saveRestaurantMenu(Long restaurantId, CreateRestaurantMenuDto createRestaurantMenuDto, String menuImageUrl) {
-        Restaurant restaurant = restaurantRepository.findById(restaurantId).orElseThrow(() -> new CustomException(ResponseCode.RESTAURANT_NOT_FOUND));
+        Restaurant restaurant = getRestaurantById(restaurantId);
         if (!Objects.equals(createRestaurantMenuDto.getOwnerId(), restaurant.getOwnerId()))
             throw new CustomException(ResponseCode.NOT_RESTAURANT_OWNER);
 
@@ -92,7 +93,7 @@ public class RestaurantService {
     // 특정 식당 메뉴 수정
     @Transactional
     public void updateRestaurantMenu(Long restaurantId, Long menuId, UpdateRestaurantMenuDto restaurantMenuDto) {
-        Restaurant restaurant = restaurantRepository.findById(restaurantId).orElseThrow(() -> new CustomException(ResponseCode.RESTAURANT_NOT_FOUND));
+        Restaurant restaurant = getRestaurantById(restaurantId);
         if (!Objects.equals(restaurantMenuDto.getOwnerId(), restaurant.getOwnerId()))
             throw new CustomException(ResponseCode.NOT_RESTAURANT_OWNER);
         restaurant.updateRestaurantMenu(menuId, restaurantMenuDto);
@@ -102,11 +103,14 @@ public class RestaurantService {
     // 특정 식당 메뉴 삭제
     @Transactional
     public void deleteRestaurantMenu(Long restaurantId, Long menuId, DeleteRestaurantMenuDto deleteRestaurantMenuDto) {
-        Restaurant restaurant = restaurantRepository.findById(restaurantId).orElseThrow(() -> new CustomException(ResponseCode.RESTAURANT_NOT_FOUND));
+        Restaurant restaurant = getRestaurantById(restaurantId);
         if (!Objects.equals(deleteRestaurantMenuDto.getOwnerId(), restaurant.getOwnerId()))
             throw new CustomException(ResponseCode.NOT_RESTAURANT_OWNER);
         restaurant.deleteRestaurantMenu(menuId);
         restaurantRepository.save(restaurant);
     }
 
+    public Restaurant getRestaurantById(Long userId) {
+        return restaurantRepository.findById(userId).orElseThrow(() -> new CustomException(ResponseCode.RESTAURANT_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/kusher/kusher_in_korea/tabling/service/RestaurantService.java
+++ b/src/main/java/com/kusher/kusher_in_korea/tabling/service/RestaurantService.java
@@ -2,7 +2,6 @@ package com.kusher.kusher_in_korea.tabling.service;
 
 import com.kusher.kusher_in_korea.tabling.domain.Restaurant;
 import com.kusher.kusher_in_korea.tabling.domain.RestaurantMenu;
-import com.kusher.kusher_in_korea.auth.domain.User;
 import com.kusher.kusher_in_korea.tabling.dto.request.*;
 import com.kusher.kusher_in_korea.tabling.dto.response.RestaurantDto;
 import com.kusher.kusher_in_korea.tabling.dto.response.RestaurantMenuDto;
@@ -16,7 +15,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -69,10 +67,9 @@ public class RestaurantService {
     // 특정 식당 정보 수정
     @Transactional
     public Long updateRestaurant(Long restaurantId, UpdateRestaurantDto restaurantDto) {
-        Long userId = restaurantDto.getUserId();
-        if (!isOwner(restaurantId, userId)) throw new CustomException(ResponseCode.NOT_RESTAURANT_OWNER);
-
         Restaurant restaurant = getRestaurantById(restaurantId);
+        if (!isOwner(restaurant.getOwnerId(), restaurantDto.getUserId()))
+            throw new CustomException(ResponseCode.NOT_RESTAURANT_OWNER);
         restaurant.updateRestaurant(restaurantDto);
         restaurantRepository.save(restaurant);
         return restaurant.getId();
@@ -82,9 +79,8 @@ public class RestaurantService {
     @Transactional
     public Long saveRestaurantMenu(Long restaurantId, CreateRestaurantMenuDto createRestaurantMenuDto, String menuImageUrl) {
         Restaurant restaurant = getRestaurantById(restaurantId);
-        if (!Objects.equals(createRestaurantMenuDto.getOwnerId(), restaurant.getOwnerId()))
+        if (!isOwner(restaurant.getOwnerId(), createRestaurantMenuDto.getOwnerId()))
             throw new CustomException(ResponseCode.NOT_RESTAURANT_OWNER);
-
         restaurant.addRestaurantMenu(createRestaurantMenuDto, menuImageUrl);
         restaurantRepository.save(restaurant);
         return restaurant.getId();
@@ -94,7 +90,7 @@ public class RestaurantService {
     @Transactional
     public void updateRestaurantMenu(Long restaurantId, Long menuId, UpdateRestaurantMenuDto restaurantMenuDto) {
         Restaurant restaurant = getRestaurantById(restaurantId);
-        if (!Objects.equals(restaurantMenuDto.getOwnerId(), restaurant.getOwnerId()))
+        if (!isOwner(restaurant.getOwnerId(), restaurantMenuDto.getOwnerId()))
             throw new CustomException(ResponseCode.NOT_RESTAURANT_OWNER);
         restaurant.updateRestaurantMenu(menuId, restaurantMenuDto);
         restaurantRepository.save(restaurant);
@@ -104,7 +100,7 @@ public class RestaurantService {
     @Transactional
     public void deleteRestaurantMenu(Long restaurantId, Long menuId, DeleteRestaurantMenuDto deleteRestaurantMenuDto) {
         Restaurant restaurant = getRestaurantById(restaurantId);
-        if (!Objects.equals(deleteRestaurantMenuDto.getOwnerId(), restaurant.getOwnerId()))
+        if (!isOwner(restaurant.getOwnerId(), deleteRestaurantMenuDto.getOwnerId()))
             throw new CustomException(ResponseCode.NOT_RESTAURANT_OWNER);
         restaurant.deleteRestaurantMenu(menuId);
         restaurantRepository.save(restaurant);

--- a/src/main/java/com/kusher/kusher_in_korea/util/api/ApiBody.java
+++ b/src/main/java/com/kusher/kusher_in_korea/util/api/ApiBody.java
@@ -1,6 +1,7 @@
 package com.kusher.kusher_in_korea.util.api;
 
 public class ApiBody<T> {
+
     private final T data;
     private final T msg;
 

--- a/src/main/java/com/kusher/kusher_in_korea/util/api/ApiHeader.java
+++ b/src/main/java/com/kusher/kusher_in_korea/util/api/ApiHeader.java
@@ -1,6 +1,7 @@
 package com.kusher.kusher_in_korea.util.api;
 
 public class ApiHeader {
+
     private final int resultCode;
     private final String codeName;
 

--- a/src/main/java/com/kusher/kusher_in_korea/util/exception/CustomException.java
+++ b/src/main/java/com/kusher/kusher_in_korea/util/exception/CustomException.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class CustomException extends RuntimeException {
+
     private final ResponseCode responseCode;
 
     @Override

--- a/src/main/java/com/kusher/kusher_in_korea/util/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kusher/kusher_in_korea/util/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.context.request.WebRequest;
 @Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
+
     @ExceptionHandler(value = {CustomException.class})
     // 예외 발생 시 클라이언트에게 전달할 응답을 생성하는 메소드
     public ResponseEntity<ApiResponse> handleCustomException(CustomException e, WebRequest request) {

--- a/src/main/java/com/kusher/kusher_in_korea/util/exception/PaymentException.java
+++ b/src/main/java/com/kusher/kusher_in_korea/util/exception/PaymentException.java
@@ -1,12 +1,14 @@
 package com.kusher.kusher_in_korea.util.exception;
 
 public class PaymentException extends Exception {
+
     private static final long serialVersionUID = 1L;
+
     public PaymentException(String message) {
         super(message);
     } // constructor #1
+
     public PaymentException(Exception e) {
         super(e);
     } // constructor #2
-
 }

--- a/src/main/java/com/kusher/kusher_in_korea/util/exception/ResponseCode.java
+++ b/src/main/java/com/kusher/kusher_in_korea/util/exception/ResponseCode.java
@@ -39,6 +39,8 @@ public enum ResponseCode {
     DUPLICATED_USER(HttpStatus.CONFLICT, false,"Duplicated User"),
     DUPLICATED_RESTAURANT(HttpStatus.CONFLICT, false,"Duplicated Restaurant"),
     DUPLICATED_RESERVATION(HttpStatus.CONFLICT, false,"Duplicated Reservation"),
+    DUPLICATED_CATEGORY(HttpStatus.CONFLICT, false,"Duplicated Category"),
+    DUPLICATED_INGREDIENT(HttpStatus.CONFLICT, false,"Duplicated Cart Ingredient"),
 
     /**
      * 500 INTERNAL SERVER ERROR

--- a/src/main/java/com/kusher/kusher_in_korea/util/exception/ResponseCode.java
+++ b/src/main/java/com/kusher/kusher_in_korea/util/exception/ResponseCode.java
@@ -17,6 +17,7 @@ public enum ResponseCode {
     NOT_RESTAURANT_OWNER(HttpStatus.BAD_REQUEST, false,"Not Restaurant Owner"),
     ALREADY_REVIEWED(HttpStatus.BAD_REQUEST, false,"Already Reviewed"),
     ALREADY_DELIVERED(HttpStatus.BAD_REQUEST, false,"Already Delivered"),
+    ALREADY_CANCELED(HttpStatus.BAD_REQUEST, false,"Already Canceled"),
 
     /**
      * 404 NOT FOUND


### PR DESCRIPTION
- [x] Service 내부 반복되는 로직(특히 findBy) 따로 메서드로 분리
- [x] 존재 여부만 파악하는 로직은 findBy보다는 existsBy로 개선
- [x] 코드 정리하는 습관, 클래스 첫줄 개행 여부 통일
- [x] CustomException/ResponseCode 누락된 부분 수정
- [x] Cascade ALL 다른 값으로 대체
- [x] 생성메서드인데 기본생성자가 protected가 아닌 경우 수정
- [x] Setter가 필수가 아닌 객체에 @DaTa 사용한 부분 수정 (domain, dto)
- [x] Reservation 생성 API 반환값 Long -> ReservationDto로 수정
- [ ] Entity가 Dto에 의존하고 있는 상황 해소 (추후 issue에서 개선)